### PR TITLE
Migrate hosting to DigitalOcean App Platform

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -37,15 +37,24 @@ services:
       #   SUPABASE_SERVICE_ROLE_KEY -> lib/supabase/admin.ts
       #   ADMIN_EMAIL               -> lib/auth/admin.ts
       # lib/env.ts throws on a missing value rather than degrading, so the
-      # admin paths fail loudly until these are set in the DO dashboard.
+      # admin paths fail loudly rather than silently misbehaving.
+      #
+      # A genuine secret - it bypasses RLS. Left empty in the committed spec and
+      # set out of band. Applying this file as-is would NOT blank the stored
+      # value, but do not paste one in here either.
       - key: SUPABASE_SERVICE_ROLE_KEY
         scope: RUN_TIME
         type: SECRET
         value: ""
+      # NOT a secret, despite the plan declaring it one. This exact address is
+      # rendered publicly on the homepage as the primary contact link, and it is
+      # only ever compared against the email on an already-authenticated
+      # session, so knowing it grants nothing. Keeping it as a plain value makes
+      # the app reproducible from this spec instead of requiring a manual
+      # dashboard step to recreate.
       - key: ADMIN_EMAIL
         scope: RUN_TIME
-        type: SECRET
-        value: ""
+        value: "beasley.patrick@gmail.com"
       # NEXT_PUBLIC_SITE_URL is deliberately NOT set. It is absent from Vercel
       # production too, so the code defaults already describe live behaviour:
       # getSiteUrl() falls back to the www host, while layout/robots/sitemap

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,78 @@
+name: personal-homepage
+region: nyc
+# App Platform fronts with Cloudflare, which rewrites email addresses in the
+# served HTML by default: beasley.patrick@gmail.com becomes [email protected]
+# and the mailto: href becomes /cdn-cgi/l/email-protection#<hex>, restored only
+# by a Cloudflare JS decoder. This page says "Email is the best way to reach
+# me", so that link is the site's primary call to action and it silently stops
+# working without JavaScript. Vercel served a plain mailto:, so this keeps the
+# migration behaviour-preserving. Flip to false to take Cloudflare's scraper
+# protection instead - a deliberate product decision, not a hosting detail.
+disable_email_obfuscation: true
+services:
+  - name: web
+    github:
+      repo: S-Tier-Devs/personal-homepage
+      branch: main
+      deploy_on_push: true
+    build_command: npm run build
+    run_command: npm start
+    environment_slug: node-js
+    instance_size_slug: basic-xxs
+    instance_count: 1
+    http_port: 3000
+    envs:
+      # NEXT_PUBLIC_* are inlined by Next.js at build time by literal text
+      # replacement, so BUILD_TIME scope is load-bearing. See lib/env.ts, which
+      # documents why these must stay static process.env references.
+      # Both values are filled in locally at app-create time and left empty
+      # here rather than committed.
+      - key: NEXT_PUBLIC_SUPABASE_URL
+        scope: BUILD_TIME
+        value: ""
+      - key: NEXT_PUBLIC_SUPABASE_ANON_KEY
+        scope: BUILD_TIME
+        value: ""
+      # Both of these ARE used by this app, unlike jennys-homepage:
+      #   SUPABASE_SERVICE_ROLE_KEY -> lib/supabase/admin.ts
+      #   ADMIN_EMAIL               -> lib/auth/admin.ts
+      # lib/env.ts throws on a missing value rather than degrading, so the
+      # admin paths fail loudly until these are set in the DO dashboard.
+      - key: SUPABASE_SERVICE_ROLE_KEY
+        scope: RUN_TIME
+        type: SECRET
+        value: ""
+      - key: ADMIN_EMAIL
+        scope: RUN_TIME
+        type: SECRET
+        value: ""
+      # NEXT_PUBLIC_SITE_URL is deliberately NOT set. It is absent from Vercel
+      # production too, so the code defaults already describe live behaviour:
+      # getSiteUrl() falls back to the www host, while layout/robots/sitemap
+      # fall back to the apex. Setting it here would change canonical and
+      # sitemap URLs during a hosting migration. Unify it as its own change.
+domains:
+  - domain: www.patrickbeasley.com
+    type: PRIMARY
+  - domain: patrickbeasley.com
+    type: ALIAS
+ingress:
+  rules:
+    # Preserve the apex -> www redirect. On Vercel the apex 307-redirects to
+    # www, and this app treats www as canonical (lib/env.ts getSiteUrl, which
+    # magic-link redirect targets depend on). App Platform ALIAS domains SERVE
+    # rather than redirect - verified on pogo-db and jennsbeans, where the
+    # alias returns 200 - so without this rule the redirect silently
+    # disappears and both hosts serve identical content.
+    # This rule must come first; the catch-all below would otherwise match.
+    - match:
+        authority:
+          exact: patrickbeasley.com
+      redirect:
+        authority: www.patrickbeasley.com
+        redirect_code: 308
+    - match:
+        path:
+          prefix: /
+      component:
+        name: web

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SITE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 ADMIN_EMAIL=
+# Used by the digitalocean MCP server (.mcp.json), not by the app itself.
+DIGITALOCEAN_API_TOKEN=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
 # Copilot Instructions — personal-homepage
 
 ## Purpose and Scope
-This workspace is the personal homepage for patrickbeasley.com, built with Next.js (App Router, TypeScript), Tailwind CSS, Supabase (Postgres + Auth + Storage), and deployed on Vercel. These instructions apply to all AI-assisted work in this repository.
+This workspace is the personal homepage for patrickbeasley.com, built with Next.js (App Router, TypeScript), Tailwind CSS, Supabase (Postgres + Auth + Storage), and deployed on DigitalOcean App Platform. These instructions apply to all AI-assisted work in this repository.
 
 ## Non-Negotiables
-- Never commit secrets, tokens, or credentials. All secrets go in `.env.local` (git-ignored) or Vercel environment variables.
+- Never commit secrets, tokens, or credentials. All secrets go in `.env.local` (git-ignored) or the DigitalOcean App Platform dashboard as `RUN_TIME` secrets - never in `.do/app.yaml`.
 - All auth-protected routes and API handlers must verify the session before acting.
 - Admin-only behavior must key off the `ADMIN_EMAIL` allowlist on the server side; client-side gating alone is never sufficient.
 - File uploads must be validated server-side: allowed extensions (`.pdf`, `.docx`, `.txt`, `.md`, `.sql`, `.py`) and max 10MB per file.

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -38,7 +38,7 @@ applyTo: "app/api/**,lib/**,supabase/**"
 ## Error Handling and Logging
 - Catch all async errors with try/catch in route handlers.
 - Log errors server-side with sufficient context (route, user id if available, error message).
-- Do not `console.log` in production — use a structured logger or Vercel logs.
+- Do not `console.log` in production - use a structured logger or DigitalOcean App Platform runtime logs.
 - Every API route with a TODO placeholder must be treated as a bug — never ship a user-facing route that logs instead of persists. Scan for TODO comments in `app/api/` before closing any phase.
 
 ## Contact Form

--- a/.github/skills/project-bootstrap/SKILL.md
+++ b/.github/skills/project-bootstrap/SKILL.md
@@ -32,7 +32,7 @@ description: Use when initializing a new project module or service from scratch 
 ### Stage 3 — Environment Setup
 - [ ] Create `.env.local` from `.env.example` template
 - [ ] Add: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `ADMIN_EMAIL`
-- [ ] Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` as `BUILD_TIME` values in `.do/app.yaml`; add `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` as `RUN_TIME` secrets in the DigitalOcean App Platform dashboard, never in a file
+- [ ] Set `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` (`BUILD_TIME`) and `ADMIN_EMAIL` (`RUN_TIME`, plain) in `.do/app.yaml`; set only `SUPABASE_SERVICE_ROLE_KEY` out of band as a `RUN_TIME` `SECRET`, never in a file, because it bypasses RLS
 - [ ] Verify `.env.local` is git-ignored
 - [ ] Verify `.env.example` is committed even if the repo ignores `.env*`
 
@@ -43,7 +43,7 @@ Email + password, with magic link as a backup. There is no OAuth provider — se
 - [ ] Create the admin user in Studio with **"Auto Confirm User" checked**. An unconfirmed address fails as `email_not_confirmed`, which the login form deliberately reports as the generic "Invalid email or password" — so check the Supabase auth logs, not the UI
 - [ ] Add that address to `public.admin_users`. `is_admin()` matches on **email**, not user id, so no id linkage is required
 - [ ] Leave session timebox and inactivity timeout **OFF** — this is what makes sessions last indefinitely per device
-- [ ] Add `/auth/confirm` to the redirect allowlist for local **and** production (needed for magic link only; password sign-in uses no redirect). App Platform has no per-PR preview environments, so there is no preview scope to add
+- [ ] Add `/auth/confirm` to the redirect allowlist for local **and** production (needed for magic link only; password sign-in uses no redirect). App Platform creates no preview environments of its own. Vercel previews still appear on PRs while that project is kept as the rollback path, so a magic link tested on a preview URL needs that host allowlisted too
 - [ ] Run one password sign-in and one magic-link sign-in end to end
 
 ### Stage 4 — AI Docs

--- a/.github/skills/project-bootstrap/SKILL.md
+++ b/.github/skills/project-bootstrap/SKILL.md
@@ -12,8 +12,8 @@ description: Use when initializing a new project module or service from scratch 
 
 ## Required Inputs
 - Project name and description
-- Target stack (already defined: Next.js, Supabase, Vercel, TypeScript, Tailwind)
-- Deployment target (Vercel)
+- Target stack (already defined: Next.js, Supabase, DigitalOcean App Platform, TypeScript, Tailwind)
+- Deployment target (DigitalOcean App Platform)
 - Auth provider (Supabase + Google OAuth)
 
 ## Workflow Stages
@@ -32,7 +32,7 @@ description: Use when initializing a new project module or service from scratch 
 ### Stage 3 — Environment Setup
 - [ ] Create `.env.local` from `.env.example` template
 - [ ] Add: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `ADMIN_EMAIL`
-- [ ] Add same vars to Vercel project environment settings
+- [ ] Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` as `BUILD_TIME` values in `.do/app.yaml`; add `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` as `RUN_TIME` secrets in the DigitalOcean App Platform dashboard, never in a file
 - [ ] Verify `.env.local` is git-ignored
 - [ ] Verify `.env.example` is committed even if the repo ignores `.env*`
 
@@ -43,7 +43,7 @@ Email + password, with magic link as a backup. There is no OAuth provider — se
 - [ ] Create the admin user in Studio with **"Auto Confirm User" checked**. An unconfirmed address fails as `email_not_confirmed`, which the login form deliberately reports as the generic "Invalid email or password" — so check the Supabase auth logs, not the UI
 - [ ] Add that address to `public.admin_users`. `is_admin()` matches on **email**, not user id, so no id linkage is required
 - [ ] Leave session timebox and inactivity timeout **OFF** — this is what makes sessions last indefinitely per device
-- [ ] Add `/auth/confirm` to the redirect allowlist for local, preview **and** production (needed for magic link only; password sign-in uses no redirect)
+- [ ] Add `/auth/confirm` to the redirect allowlist for local **and** production (needed for magic link only; password sign-in uses no redirect). App Platform has no per-PR preview environments, so there is no preview scope to add
 - [ ] Run one password sign-in and one magic-link sign-in end to end
 
 ### Stage 4 — AI Docs
@@ -71,11 +71,11 @@ Email + password, with magic link as a backup. There is no OAuth provider — se
 - [ ] `npm run lint` passes
 - [ ] `npm run build` passes
 - [ ] No secrets in git history (`git log --all -p | Select-String "ghp_|sk_|secret"`)
-- [ ] Vercel auto-deploy triggers on push to main
+- [ ] DigitalOcean App Platform auto-deploys `main` on merge (`deploy_on_push: true` in `.do/app.yaml`)
 - [ ] Supabase migration dry run reports expected SQL before apply and "up to date" after apply
 
 ## Failure Handling
 - If `create-next-app` fails midway, delete the directory and retry with `--yes` flag
-- If Vercel deploy fails, check environment variables match `.env.example` names exactly
+- If the DigitalOcean App Platform deploy fails, check environment variables match `.env.example` names exactly
 - If Supabase connection fails, verify `NEXT_PUBLIC_SUPABASE_URL` does not have a trailing slash
 - If git push requires a temporary credentialed remote URL, reset the remote to a clean HTTPS URL immediately after the push succeeds

--- a/.github/skills/release-readiness/SKILL.md
+++ b/.github/skills/release-readiness/SKILL.md
@@ -19,7 +19,7 @@ description: Use before deploying to production — verifies build, tests, env p
 - [ ] No TypeScript errors (`npx tsc --noEmit`)
 
 ### Environment Parity
-- [ ] All `.env.example` variables are set in Vercel production environment
+- [ ] `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are correct `BUILD_TIME` values in `.do/app.yaml`; `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` are set as `RUN_TIME` secrets in the DigitalOcean dashboard
 - [ ] `NEXT_PUBLIC_SUPABASE_URL` points to production Supabase project (not local/staging)
 - [ ] `ADMIN_EMAIL` is set to the correct production admin address
 - [ ] No development-only flags or debug logging enabled in production build
@@ -30,7 +30,7 @@ description: Use before deploying to production — verifies build, tests, env p
 - [ ] No pending schema changes that conflict with deployed code
 
 ### Domain and Routing
-- [ ] `patrickbeasley.com` DNS records point to Vercel
+- [ ] `patrickbeasley.com` DNS records point to the DigitalOcean App Platform app; apex redirects to `www.patrickbeasley.com` per the ingress rule in `.do/app.yaml`
 - [ ] SSL certificate active and auto-renewing
 - [ ] `www.` redirect configured if needed
 - [ ] All internal links use relative paths or the production domain
@@ -62,8 +62,8 @@ description: Use before deploying to production — verifies build, tests, env p
 | Download private file as anonymous | Access denied |
 
 ## Rollback Readiness
-- [ ] Previous working deployment is identifiable in Vercel dashboard
-- [ ] Rollback to previous Vercel deployment tested (requires no schema rollback)
+- [ ] Previous working deployment is identifiable in the DigitalOcean App Platform dashboard
+- [ ] Rollback to a previous DigitalOcean App Platform deployment tested (requires no schema rollback)
 - [ ] If schema changed, rollback SQL is documented in migration file
 
 ## Release Notes Template

--- a/.github/skills/release-readiness/SKILL.md
+++ b/.github/skills/release-readiness/SKILL.md
@@ -19,7 +19,7 @@ description: Use before deploying to production — verifies build, tests, env p
 - [ ] No TypeScript errors (`npx tsc --noEmit`)
 
 ### Environment Parity
-- [ ] `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are correct `BUILD_TIME` values in `.do/app.yaml`; `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` are set as `RUN_TIME` secrets in the DigitalOcean dashboard
+- [ ] `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` (`BUILD_TIME`) and `ADMIN_EMAIL` (`RUN_TIME`, plain) are correct in `.do/app.yaml`; `SUPABASE_SERVICE_ROLE_KEY` is a `RUN_TIME` `SECRET` with a real value set out of band. Note an empty secret encrypts to an `EV[...]` blob that looks identical to a real one in the dashboard, so confirm it by behaviour, not by appearance
 - [ ] `NEXT_PUBLIC_SUPABASE_URL` points to production Supabase project (not local/staging)
 - [ ] `ADMIN_EMAIL` is set to the correct production admin address
 - [ ] No development-only flags or debug logging enabled in production build

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,16 @@
       "env": {
         "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
       }
+    },
+    "digitalocean": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@digitalocean/mcp"
+      ],
+      "env": {
+        "DIGITALOCEAN_API_TOKEN": "${DIGITALOCEAN_API_TOKEN}"
+      }
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,12 @@ Public one-pager at `/`, private dashboard at `/dashboard`. Supabase provides Po
 
 **`design/patrick-beasley.dc.html` is the behavioural spec.** Cite its line numbers; do not paraphrase it from memory.
 
+## Deploy target
+
+DigitalOcean App Platform, app `personal-homepage`, region `nyc`. `.do/app.yaml` is the source of truth for the app spec - **never edit the app in the DO web console**, or the console and the spec drift. Production deploys from `main` on merge (`deploy_on_push: true`).
+
+The spec declares four env vars: `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` at `BUILD_TIME` (Next.js inlines `NEXT_PUBLIC_*` at build time), plus `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` as `RUN_TIME` secrets. The two secrets are set in the DO dashboard only, never committed to a file.
+
 ## Binding conventions
 
 `components/dashboard/links/` and `app/api/links/` are the reference implementation. Mirror them rather than inventing a new shape.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Public one-pager at `/`, private dashboard at `/dashboard`. Supabase provides Po
 
 DigitalOcean App Platform, app `personal-homepage`, region `nyc`. `.do/app.yaml` is the source of truth for the app spec - **never edit the app in the DO web console**, or the console and the spec drift. Production deploys from `main` on merge (`deploy_on_push: true`).
 
-The spec declares four env vars: `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` at `BUILD_TIME` (Next.js inlines `NEXT_PUBLIC_*` at build time), plus `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` as `RUN_TIME` secrets. The two secrets are set in the DO dashboard only, never committed to a file.
+The spec declares four env vars: `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` at `BUILD_TIME` (Next.js inlines `NEXT_PUBLIC_*` at build time), plus `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` at `RUN_TIME`. Only `SUPABASE_SERVICE_ROLE_KEY` is a secret: it bypasses RLS, so it is `type: SECRET`, empty in the committed spec, and set out of band. `ADMIN_EMAIL` is a plain spec value; it is the contact address this site publishes and is only compared against an already-authenticated session, so it is not sensitive and belongs in the spec so the app is reproducible from it.
 
 ## Binding conventions
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Required environment variables for local development, see `.env.example`:
 - `SUPABASE_SERVICE_ROLE_KEY`
 - `ADMIN_EMAIL`
 
-In production (`.do/app.yaml`), `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are `BUILD_TIME` values baked in at build time; `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` are `RUN_TIME` secrets set in the DigitalOcean dashboard, never in a file. `NEXT_PUBLIC_SITE_URL` is deliberately not set in production, `getSiteUrl()` in `lib/env.ts` falls back to the `www` host. There is no separate preview scope: App Platform does not create per-PR preview environments, so verify locally (`npm run build && npm start`) before merge, and check production after merge.
+In production (`.do/app.yaml`), `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are `BUILD_TIME` values baked in at build time. `SUPABASE_SERVICE_ROLE_KEY` is the only real secret: `RUN_TIME`, `type: SECRET`, empty in the committed spec and set out of band, because it bypasses RLS. `ADMIN_EMAIL` is a plain `RUN_TIME` value in the spec, not a secret - it is the address this site publishes as its contact link, and it is only compared against an already-authenticated session, so keeping it in the spec costs nothing and lets the app be recreated from that file alone. `NEXT_PUBLIC_SITE_URL` is deliberately not set in production, `getSiteUrl()` in `lib/env.ts` falls back to the `www` host.
 
 Never commit `.env.local`.
 
@@ -82,7 +82,7 @@ npm run build
 
 Hosted on DigitalOcean App Platform, app `personal-homepage`, region `nyc`. `.do/app.yaml` is the source of truth for the app spec, including domains, ingress rules and env var scoping - never edit the app in the DO web console, or the console and the spec drift.
 
-Production deploys from `main` on merge (`deploy_on_push: true`). There are no per-PR preview environments; verify locally with `npm run build && npm start` before merge, and check production after merge.
+Production deploys from `main` on merge (`deploy_on_push: true`). App Platform does not create per-PR preview environments. A Vercel preview URL may still appear on PRs, because the Vercel project is deliberately kept connected as the hosting rollback path; it disappears when that project is deleted at teardown. Verify locally with `npm run build && npm start` before merge, and check production after merge.
 
 `www.patrickbeasley.com` is canonical. The apex `patrickbeasley.com` redirects to it via an ingress rule in `.do/app.yaml` - it does not serve content directly.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | Framework | Next.js 16 (App Router, TypeScript) |
 | Styling | Tailwind CSS v4 |
 | Database, auth, storage | Supabase |
-| Hosting | Vercel |
+| Hosting | DigitalOcean App Platform |
 
 ## What it is
 
@@ -59,14 +59,17 @@ cp .env.example .env.local   # then fill it in
 npm run dev
 ```
 
-Required environment variables — all four must also exist in Vercel for **both** Preview and Production, which are separate scopes:
+Required environment variables for local development, see `.env.example`:
 
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 - `NEXT_PUBLIC_SITE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
 - `ADMIN_EMAIL`
 
-`SUPABASE_SERVICE_ROLE_KEY` is used only for administrative scripts, never by the app. Never commit `.env.local`.
+In production (`.do/app.yaml`), `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` are `BUILD_TIME` values baked in at build time; `SUPABASE_SERVICE_ROLE_KEY` and `ADMIN_EMAIL` are `RUN_TIME` secrets set in the DigitalOcean dashboard, never in a file. `NEXT_PUBLIC_SITE_URL` is deliberately not set in production, `getSiteUrl()` in `lib/env.ts` falls back to the `www` host. There is no separate preview scope: App Platform does not create per-PR preview environments, so verify locally (`npm run build && npm start`) before merge, and check production after merge.
+
+Never commit `.env.local`.
 
 ```bash
 npm run lint
@@ -74,6 +77,16 @@ npx tsc --noEmit
 npm test
 npm run build
 ```
+
+## Deployment
+
+Hosted on DigitalOcean App Platform, app `personal-homepage`, region `nyc`. `.do/app.yaml` is the source of truth for the app spec, including domains, ingress rules and env var scoping - never edit the app in the DO web console, or the console and the spec drift.
+
+Production deploys from `main` on merge (`deploy_on_push: true`). There are no per-PR preview environments; verify locally with `npm run build && npm start` before merge, and check production after merge.
+
+`www.patrickbeasley.com` is canonical. The apex `patrickbeasley.com` redirects to it via an ingress rule in `.do/app.yaml` - it does not serve content directly.
+
+There is no container registry; DigitalOcean builds from GitHub source (`S-Tier-Devs/personal-homepage`) using buildpacks.
 
 ## Design source
 


### PR DESCRIPTION
Adds .do/app.yaml as the source of truth and updates the docs that asserted
Vercel hosting. Supabase is unchanged; only hosting moves.

Two behaviours App Platform does not reproduce by default, both preserved here
rather than discovered later:

Vercel 307-redirects the apex to www, and this app treats www as canonical
(lib/env.ts getSiteUrl, which magic-link redirect targets depend on). App
Platform ALIAS domains serve rather than redirect, so an ingress rule restores
the redirect as a 308.

App Platform fronts with Cloudflare, which rewrites the contact mailto: into
/cdn-cgi/l/email-protection. The page calls email the best way to reach me, so
disable_email_obfuscation keeps it a plain mailto.

Unlike jennys-homepage, SUPABASE_SERVICE_ROLE_KEY is genuinely used here
(lib/supabase/admin.ts) and stays in the spec as a dashboard-set secret,
alongside ADMIN_EMAIL (lib/auth/admin.ts). lib/env.ts throws on a missing
value rather than degrading.

Corrects the repo owner to S-Tier-Devs, and a README claim that the
service-role key is never used by the app.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014neh4dP4ttxPGDjeFSk6iH
